### PR TITLE
Fixing DatePicker Enabled Date

### DIFF
--- a/source/apps/website/src/i18n/en/createRace.json
+++ b/source/apps/website/src/i18n/en/createRace.json
@@ -4,7 +4,7 @@
     "BEST_LAP_TIME": "Best lap time",
     "chooseAccessType": "Choose access type",
     "chooseRaceDates": "Choose race dates",
-    "chooseRaceDatesDesc": "Choose a start and close date in 24-hour format (Pacific Daylight Time) America/Los_Angeles.",
+    "chooseRaceDatesDesc": "Choose a start and close date in 24-hour format. Time is in {{timezone}}.",
     "chooseRaceType": "Choose race type",
     "chooseRaceTypeDesc": "Race types increase in complexity from left to right. For first-time racers, we recommend Time trials because models converge faster.",
     "classicRace": "Classic race",

--- a/source/apps/website/src/pages/CreateRace/components/AddRaceDetails.tsx
+++ b/source/apps/website/src/pages/CreateRace/components/AddRaceDetails.tsx
@@ -8,7 +8,7 @@ import FormField from '@cloudscape-design/components/form-field';
 import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { RaceType, TimingMethod } from '@deepracer-indy/typescript-client';
-import { MutableRefObject, useEffect } from 'react';
+import { MutableRefObject, useEffect, useMemo } from 'react';
 import { Control, useFieldArray, UseFormSetValue, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -21,7 +21,7 @@ import TilesField from '#components/FormFields/TilesField/TilesField';
 import TimeInputField from '#components/FormFields/TimeInputField/TimeInputField';
 import TrackSelection from '#components/TrackSelection';
 import { DEFAULT_OBJECT_POSITIONS, TRACKS } from '#constants/tracks';
-import { isDateRangeInvalid } from '#utils/dateTimeUtils';
+import { getUTCOffsetTimeZoneText, isDateRangeInvalid } from '#utils/dateTimeUtils';
 
 import { CreateRaceFormValues } from '../CreateRace';
 
@@ -54,7 +54,15 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
     }
   }, [objectAvoidanceConfig.numberOfObjects, randomizeObstacles, fields.length, append, remove]);
 
-  const currentDate = new Date();
+  const { currentDate, currentDateOnly, startDateOnly } = useMemo(() => {
+    const cDate = new Date();
+    const cDateOnly = new Date(cDate.getFullYear(), cDate.getMonth(), cDate.getDate());
+    if (!startDate) return { currentDate: cDate, currentDateOnly: cDateOnly, startDateOnly: cDateOnly };
+    const sDateObj = new Date(startDate);
+    const sDateOnly = new Date(sDateObj.getFullYear(), sDateObj.getMonth(), sDateObj.getDate());
+    return { currentDate: cDate, currentDateOnly: cDateOnly, startDateOnly: sDateOnly };
+  }, [startDate]);
+
   return (
     <SpaceBetween size={'l'} direction="vertical">
       <Container
@@ -98,7 +106,7 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
           </div>
           <div>
             <FormField
-              description={t('addRaceDetails.chooseRaceDatesDesc')}
+              description={t('addRaceDetails.chooseRaceDatesDesc', { timezone: getUTCOffsetTimeZoneText() })}
               label={t('addRaceDetails.chooseRaceDates')}
               stretch
             >
@@ -107,7 +115,7 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
                   name="startDate"
                   control={control}
                   placeholder="YYYY/MM/DD"
-                  isDateEnabled={(date) => date >= new Date(currentDate.toLocaleDateString())}
+                  isDateEnabled={(date) => date >= currentDateOnly}
                 />
                 <TimeInputField
                   name="startTime"
@@ -124,9 +132,7 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
                   name="endDate"
                   control={control}
                   placeholder="YYYY/MM/DD"
-                  isDateEnabled={(date) =>
-                    date >= new Date(startDate) && date >= new Date(currentDate.toLocaleDateString())
-                  }
+                  isDateEnabled={(date) => date >= startDateOnly && date >= currentDateOnly}
                   disabled={startDate === ''}
                 />
                 <TimeInputField


### PR DESCRIPTION
_Issue #:_ #6  

_Description of changes:_
This pull request improves the user experience for selecting race dates by updating the displayed timezone information and refining date selection logic in the race creation form. The changes ensure that users see the correct timezone and can only select valid date ranges.

**Date and Timezone Display Improvements:**

* The race date description in the English translation file (`createRace.json`) now dynamically displays the timezone using a template variable, making the information clearer for users.
* The race creation form's date field description now uses the `getUTCOffsetTimeZoneText()` utility to show the correct timezone offset to users.

**Date Selection Logic Enhancements:**

* The logic for enabling selectable dates in the race creation form has been updated to use normalized date-only values, preventing users from selecting past dates and ensuring consistency in date comparisons. [[1]](diffhunk://#diff-9bd31a33f060d7d863d5c67e9dae6af4df1959249a2e3a63d222f1a15f527036L57-R65) [[2]](diffhunk://#diff-9bd31a33f060d7d863d5c67e9dae6af4df1959249a2e3a63d222f1a15f527036L110-R118) [[3]](diffhunk://#diff-9bd31a33f060d7d863d5c67e9dae6af4df1959249a2e3a63d222f1a15f527036L127-R135)

**Code Quality Improvements:**

* The `getUTCOffsetTimeZoneText` utility is now imported where needed, and `useMemo` is used to optimize date calculations, reducing unnecessary re-computation. [[1]](diffhunk://#diff-9bd31a33f060d7d863d5c67e9dae6af4df1959249a2e3a63d222f1a15f527036L11-R11) [[2]](diffhunk://#diff-9bd31a33f060d7d863d5c67e9dae6af4df1959249a2e3a63d222f1a15f527036L24-R24)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
