### PR TITLE
Release v1.0.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,17 +23,17 @@ assignees: ""
 - [ ] Version: [e.g. v1.0.0]
 
 To get the version of the solution, you can look at the description of the created
-CloudFormation stack. For example, _"(SO0284) Innovation Sandbox on AWS Stack, v1.0.0"_.
+CloudFormation stack. For example, _"(SO0310) - DeepRacer on AWS. Version v1.0.0"_.
 
 - [ ] Region: [e.g. us-east-1]
 - [ ] Was the solution modified from the version published on this repository?
 - [ ] If the answer to the previous question was yes, are the changes available on
       GitHub?
 - [ ] Have you checked your [service quotas]
-      (https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html)
+      (https://docs.aws.amazon.com/solutions/latest/deepracer-on-aws/quotas.html)
       for the sevices this solution uses?
 - [ ] Were there any errors in the CloudWatch Logs? [Troubleshooting]
-      (https link to troubleshooting in docs.aws.amazon.com for solution)
+      (https://docs.aws.amazon.com/solutions/latest/deepracer-on-aws/troubleshooting-the-solution.html)
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem (please **DO NOT include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-02-18
+
+### Security
+
+- Update dependencies to mitigate [CVE-2026-25990](https://nvd.nist.gov/vuln/detail/CVE-2026-25990) and [CVE-2026-26007](https://nvd.nist.gov/vuln/detail/CVE-2026-26007).
+
 ## [1.0.4] - 2026-02-13
 
 ### Security

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO0310
 name: deepracer-on-aws
-version: v1.0.4
+version: v1.0.5
 cloudformation_templates:
   - template: deepracer-on-aws.template
     main_template: true


### PR DESCRIPTION
## [1.0.5] - 2026-02-18

### Security

- Update dependencies to mitigate [CVE-2026-25990](https://nvd.nist.gov/vuln/detail/CVE-2026-25990) and [CVE-2026-26007](https://nvd.nist.gov/vuln/detail/CVE-2026-26007).

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
