### PR TITLE
Improve lap management for races

### DIFF
--- a/source/apps/website/src/components/RaceOverview/components/RaceRulesColumn.tsx
+++ b/source/apps/website/src/components/RaceOverview/components/RaceRulesColumn.tsx
@@ -30,6 +30,7 @@ const RaceRulesColumn = ({ leaderboard }: RaceRulesColumnProps) => {
           </RuleLabelWithPopover>
           <Box margin={{ bottom: 'xxxs' }}>{t('raceRulesColumn.style')}</Box>
           <Box margin={{ bottom: 'xxxs' }}>{t('raceRulesColumn.entryCriteria')}</Box>
+          <Box margin={{ bottom: 'xxxs' }}>{t('raceRulesColumn.maximumLaps')}</Box>
           <RuleLabelWithPopover
             content={t('raceRulesColumn.resetsPopoverContent')}
             header={t('raceRulesColumn.resets')}
@@ -58,6 +59,9 @@ const RaceRulesColumn = ({ leaderboard }: RaceRulesColumnProps) => {
           <Box margin={{ bottom: 'xxxs' }}>{t('raceRulesColumn.individualLap')}</Box>
           <Box margin={{ bottom: 'xxxs' }}>
             {t('raceRulesColumn.consecutiveLapCount', { count: submissionTerminationConditions.minimumLaps })}
+          </Box>
+          <Box margin={{ bottom: 'xxxs' }}>
+            {t('raceRulesColumn.maximumLapCount', { count: submissionTerminationConditions.maximumLaps })}
           </Box>
           <Box margin={{ bottom: 'xxxs' }}>{t('raceRulesColumn.resetCountUnlimited')}</Box>
           {resettingBehaviorConfig?.offTrackPenaltySeconds && (

--- a/source/apps/website/src/i18n/en/createRace.json
+++ b/source/apps/website/src/i18n/en/createRace.json
@@ -42,6 +42,12 @@
     "maxSubmissionsPerUser": "Max number of submissions per user",
     "minimumLaps": "Minimum laps",
     "minimumLapsDesc": "Choose the number of laps required for a model to pass evaluation.",
+    "minimumLapsBestLapDesc": "Minimum number of laps a model must complete before its best single lap counts.",
+    "minimumLapsAvgLapLabel": "Averaging window",
+    "minimumLapsAvgLapDesc": "Number of consecutive laps used to calculate the average lap time. The best such window across the run is used as the score.",
+    "minimumLapsTotalTimeDesc": "Locked to maximum laps — all models must complete the same number of laps for total time to be comparable.",
+    "maximumLaps": "Maximum laps",
+    "maximumLapsDesc": "Choose the total number of laps to race.",
     "nameOfRacingEvent": "Name of racing event",
     "nameOfRacingEventDesc": "The racing event name must be 1 to 64 characters.",
     "nameOfRacingEventNoMatch": "The racing event name must have at least 1 non-whitespace character.",
@@ -84,7 +90,8 @@
       "endDateBeforeStartDate": "End date must not be before start date.",
       "endTimeBeforeStartTime": "End time must be after start time.",
       "startDateInPast": "Start date must not be in the past.",
-      "startTimeInPast": "Start time must be in the future."
+      "startTimeInPast": "Start time must be in the future.",
+      "maxLapsLessThanMinLaps": "Maximum laps must be greater than or equal to minimum laps."
     }
   },
   "cancel": "Cancel",

--- a/source/apps/website/src/i18n/en/raceDetails.json
+++ b/source/apps/website/src/i18n/en/raceDetails.json
@@ -29,6 +29,7 @@
     "rankingMethod": "Ranking method",
     "style": "Style",
     "entryCriteria": "Entry Criteria",
+    "maximumLaps": "Maximum laps",
     "resets": "Resets",
     "offTrackPenalty": "Off-track penalty",
     "rankingMethodPopoverContents": {
@@ -46,6 +47,8 @@
     "individualLap": "Individual lap",
     "consecutiveLapCount_one": "{{count}} consecutive lap",
     "consecutiveLapCount_other": "{{count}} consecutive laps",
+    "maximumLapCount_one": "{{count}} lap total",
+    "maximumLapCount_other": "{{count}} laps total",
     "resetCountUnlimited": "Unlimited resets",
     "secondCount_one": "{{count, number}} second",
     "secondCount_other": "{{count, number}} seconds",

--- a/source/apps/website/src/pages/CreateRace/CreateRace.tsx
+++ b/source/apps/website/src/pages/CreateRace/CreateRace.tsx
@@ -41,6 +41,7 @@ export interface CreateRaceFormValues {
   desc?: string;
   ranking: TimingMethod;
   minLap: string;
+  maxLap: string;
   offTrackPenalty: string;
   collisionPenalty: string;
   maxSubmissionsPerUser: number;
@@ -62,6 +63,7 @@ const initialRaceFormValues: CreateRaceFormValues = {
   desc: '',
   ranking: TimingMethod.TOTAL_TIME,
   minLap: '3',
+  maxLap: '5',
   offTrackPenalty: '1',
   collisionPenalty: '1',
   maxSubmissionsPerUser: 99,
@@ -147,7 +149,7 @@ const CreateRace = ({ initialFormValues = initialRaceFormValues, leaderboardId =
       },
       submissionTerminationConditions: {
         minimumLaps: Number(data.minLap),
-        maximumLaps: 5,
+        maximumLaps: Number(data.maxLap),
       },
       timingMethod: data.ranking,
       description: data.desc || undefined,

--- a/source/apps/website/src/pages/CreateRace/components/AddRaceDetails.tsx
+++ b/source/apps/website/src/pages/CreateRace/components/AddRaceDetails.tsx
@@ -39,10 +39,28 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
     name: 'objectAvoidanceConfig.objectPositions',
   });
   // For validation as user is typing dates
-  const [startDate, startTime, endDate, endTime, raceType, objectAvoidanceConfig, randomizeObstacles] = useWatch({
-    name: ['startDate', 'startTime', 'endDate', 'endTime', 'raceType', 'objectAvoidanceConfig', 'randomizeObstacles'],
-    control,
-  });
+  const [startDate, startTime, endDate, endTime, raceType, objectAvoidanceConfig, randomizeObstacles, ranking, maxLap] =
+    useWatch({
+      name: [
+        'startDate',
+        'startTime',
+        'endDate',
+        'endTime',
+        'raceType',
+        'objectAvoidanceConfig',
+        'randomizeObstacles',
+        'ranking',
+        'maxLap',
+      ],
+      control,
+    });
+
+  // For TOTAL_TIME, minimum laps must equal maximum laps — keep them in sync
+  useEffect(() => {
+    if (ranking === TimingMethod.TOTAL_TIME) {
+      setValue('minLap', maxLap);
+    }
+  }, [ranking, maxLap, setValue]);
 
   useEffect(() => {
     const objectDiff = fields.length - objectAvoidanceConfig.numberOfObjects;
@@ -195,14 +213,43 @@ const AddRaceDetails = (props: AddRaceDetailsProps) => {
             />
 
             <SelectField
-              description={t('addRaceDetails.minimumLapsDesc')}
-              label={t('addRaceDetails.minimumLaps')}
+              description={
+                ranking === TimingMethod.AVG_LAP_TIME
+                  ? t('addRaceDetails.minimumLapsAvgLapDesc')
+                  : ranking === TimingMethod.TOTAL_TIME
+                    ? t('addRaceDetails.minimumLapsTotalTimeDesc')
+                    : t('addRaceDetails.minimumLapsBestLapDesc')
+              }
+              label={
+                ranking === TimingMethod.AVG_LAP_TIME
+                  ? t('addRaceDetails.minimumLapsAvgLapLabel')
+                  : t('addRaceDetails.minimumLaps')
+              }
               name="minLap"
+              control={control}
+              disabled={ranking === TimingMethod.TOTAL_TIME}
+              options={[
+                { label: '1 lap', value: '1' },
+                { label: `2 ${t('addRaceDetails.consecutiveLaps')}`, value: '2' },
+                { label: `3 ${t('addRaceDetails.consecutiveLaps')}`, value: '3' },
+                { label: `5 ${t('addRaceDetails.consecutiveLaps')}`, value: '5' },
+                { label: `10 ${t('addRaceDetails.consecutiveLaps')}`, value: '10' },
+                { label: `20 ${t('addRaceDetails.consecutiveLaps')}`, value: '20' },
+              ]}
+            />
+
+            <SelectField
+              description={t('addRaceDetails.maximumLapsDesc')}
+              label={t('addRaceDetails.maximumLaps')}
+              name="maxLap"
               control={control}
               options={[
                 { label: '1 lap', value: '1' },
                 { label: `2 ${t('addRaceDetails.consecutiveLaps')}`, value: '2' },
                 { label: `3 ${t('addRaceDetails.consecutiveLaps')}`, value: '3' },
+                { label: `5 ${t('addRaceDetails.consecutiveLaps')}`, value: '5' },
+                { label: `10 ${t('addRaceDetails.consecutiveLaps')}`, value: '10' },
+                { label: `20 ${t('addRaceDetails.consecutiveLaps')}`, value: '20' },
               ]}
             />
 

--- a/source/apps/website/src/pages/CreateRace/components/__tests__/AddRaceDetails.spec.tsx
+++ b/source/apps/website/src/pages/CreateRace/components/__tests__/AddRaceDetails.spec.tsx
@@ -37,6 +37,7 @@ const defaultFormValues: CreateRaceFormValues = {
   desc: '',
   ranking: TimingMethod.TOTAL_TIME,
   minLap: '3',
+  maxLap: '5',
   offTrackPenalty: '1',
   collisionPenalty: '1',
   maxSubmissionsPerUser: 99,

--- a/source/apps/website/src/pages/CreateRace/validation.ts
+++ b/source/apps/website/src/pages/CreateRace/validation.ts
@@ -115,6 +115,19 @@ export const createRaceValidationSchema = Yup.object().shape({
     }),
   ranking: Yup.mixed<TimingMethod>().required(i18n.t('createRace:required')),
   minLap: Yup.string().required(i18n.t('createRace:required')),
+  maxLap: Yup.string()
+    .required(i18n.t('createRace:required'))
+    .test(
+      'maxLap-gte-minLap',
+      i18n.t('createRace:addRaceDetails.validationErrors.maxLapsLessThanMinLaps'),
+      function (maxLap) {
+        const { minLap, ranking } = this.parent;
+        if (ranking === TimingMethod.TOTAL_TIME) {
+          return Number(maxLap) === Number(minLap);
+        }
+        return Number(maxLap) >= Number(minLap);
+      },
+    ),
   offTrackPenalty: Yup.string().required(i18n.t('createRace:required')),
   collisionPenalty: Yup.string().required(i18n.t('createRace:required')),
   maxSubmissionsPerUser: Yup.number().required(i18n.t('createRace:required')),

--- a/source/apps/website/src/pages/EditRace/EditRace.tsx
+++ b/source/apps/website/src/pages/EditRace/EditRace.tsx
@@ -39,6 +39,7 @@ const EditRace = () => {
     desc: leaderboard.description || '',
     ranking: leaderboard.timingMethod,
     minLap: leaderboard.submissionTerminationConditions.minimumLaps.toString(),
+    maxLap: leaderboard.submissionTerminationConditions.maximumLaps.toString(),
     offTrackPenalty: leaderboard.resettingBehaviorConfig.offTrackPenaltySeconds?.toString() || '1',
     collisionPenalty: leaderboard.resettingBehaviorConfig.collisionPenaltySeconds?.toString() || '1',
     maxSubmissionsPerUser: leaderboard.maxSubmissionsPerUser,


### PR DESCRIPTION
## Issue

Resolves the missing ability to configure the total number of race laps when creating or editing a race.

## Description of changes

Previously the `maximumLaps` field in `SubmissionTerminationConditions` was hardcoded to `5` in the UI, even though the API, Lambda, and DynamoDB layers already fully supported it. This PR exposes the field and adds ranking-method-aware behaviour for both `minimumLaps` and `maximumLaps`.

### Changes

**`CreateRace.tsx`**
- Added `maxLap: string` to `CreateRaceFormValues`
- Wires `maximumLaps: Number(data.maxLap)` in `onNavigateStep1` instead of the hardcoded `5`

**`AddRaceDetails.tsx`**
- Added a **Maximum laps** `SelectField` (1 / 2 / 3 / 5 / 10 / 20 laps)
- The **Minimum laps** field is now ranking-method-aware:
  - **Total time** — field is disabled and locked to `maximumLaps` (all models must run the same number of laps for totals to be comparable); a `useEffect` keeps `minLap` in sync with `maxLap` automatically
  - **Average lap time** — field label changes to *"Averaging window"* and description explains it controls the consecutive-lap window used by `getBestAverageLapTime`
  - **Best lap time** — standard label with a description clarifying it is a qualification gate (model must complete ≥ N laps before its fastest single lap counts)
- `minLap` select options expanded to match `maxLap` (1 / 2 / 3 / 5 / 10 / 20)

**`validation.ts`**
- Added `maxLap` Yup rule
- Cross-field test enforces `maxLap === minLap` for `TOTAL_TIME` and `maxLap >= minLap` for other ranking methods

**`EditRace.tsx`**
- Populates `maxLap` from `leaderboard.submissionTerminationConditions.maximumLaps` on load

**`RaceRulesColumn.tsx`**
- Displays maximum laps alongside minimum laps in the race review and race details views

**`createRace.json` / `raceDetails.json`**
- Added i18n keys: `maximumLaps`, `maximumLapsDesc`, `minimumLapsBestLapDesc`, `minimumLapsAvgLapLabel`, `minimumLapsAvgLapDesc`, `minimumLapsTotalTimeDesc`, `maximumLapCount_one/other`, `maximumLaps` (rules column label)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.