### PR TITLE
release/v1.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.16] - 2026-04-16
+
+### Security
+
+- Update dependencies to mitigate [CVE-2026-27135](https://nvd.nist.gov/vuln/detail/CVE-2026-27135), [CVE-2026-28387](https://nvd.nist.gov/vuln/detail/CVE-2026-28387), [CVE-2026-31790](https://nvd.nist.gov/vuln/detail/CVE-2026-31790), and [GHSA-whj4-6x5x-4v2j](https://github.com/advisories/GHSA-whj4-6x5x-4v2j).
+
 ## [1.0.15] - 2026-04-14
 
 ### Security

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO0310
 name: deepracer-on-aws
-version: v1.0.15
+version: v1.0.16
 cloudformation_templates:
   - template: deepracer-on-aws.template
     main_template: true

--- a/source/libs/reward-function-validation/Dockerfile
+++ b/source/libs/reward-function-validation/Dockerfile
@@ -1,6 +1,13 @@
 # Fetch the base image from public ECR repository
 FROM public.ecr.aws/lambda/python:3.12
 
+# Fix OS-level CVEs - AL2023 repos are version-locked, need --releasever=latest to get security patches
+RUN microdnf update -y --releasever=latest \
+    openssl-fips-provider-latest \
+    openssl-snapsafe-libs \
+    libnghttp2 \
+    && microdnf clean all
+
 # Set up the program in the image
 COPY ./routes ${LAMBDA_TASK_ROOT}/routes
 COPY lib/reward_func_validator ${LAMBDA_TASK_ROOT}
@@ -12,8 +19,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Remove unused aws-lambda-rie to fix CVE-2025-61726
 RUN rm -f /usr/local/bin/aws-lambda-rie
 
-# Upgrade Pillow to fix CVE-2026-25990
-RUN pip install --no-cache-dir --upgrade pillow==12.1.1
+# Upgrade Pillow to fix CVEs
+RUN pip install --no-cache-dir --upgrade pillow==12.2.0
 
 # Pass the name of the function handler as an argument to the runtime
 CMD [ "lambda_function.lambda_handler" ]


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

## [1.0.16] - 2026-04-16

### Security

- Update dependencies to mitigate [CVE-2026-27135](https://nvd.nist.gov/vuln/detail/CVE-2026-27135), [CVE-2026-28387](https://nvd.nist.gov/vuln/detail/CVE-2026-28387), [CVE-2026-31790](https://nvd.nist.gov/vuln/detail/CVE-2026-31790), and [GHSA-whj4-6x5x-4v2j](https://github.com/advisories/GHSA-whj4-6x5x-4v2j).

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
