### PR TITLE
Fix: Restrict default SG

### DIFF
--- a/source/apps/infra/lib/constructs/vpc/vpcConstruct.ts
+++ b/source/apps/infra/lib/constructs/vpc/vpcConstruct.ts
@@ -16,6 +16,7 @@ export class VpcConstruct extends Construct {
 
     this.userExecutionVpc = new Vpc(this, 'userExecutionVpc', {
       natGateways: 0,
+      restrictDefaultSecurityGroup: true,
       subnetConfiguration: [
         {
           cidrMask: 24,


### PR DESCRIPTION
This pull request introduces a configuration update to the `VpcConstruct` class. The change enhances security for the `userExecutionVpc` by restricting the default security group. (Security review finding.)

Security improvements:

* Set `restrictDefaultSecurityGroup: true` in the `userExecutionVpc` configuration within `vpcConstruct.ts` to prevent unintended access via the default security group. (Which is actually unused.)

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
