### PR TITLE
fix: missing section header in changelog for release/v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.1.4] - 2026-05-28
+
+### Security
+
 - Update dependencies to mitigate [CVE-2026-44705](https://nvd.nist.gov/vuln/detail/CVE-2026-44705), [CVE-2026-9256](https://nvd.nist.gov/vuln/detail/CVE-2026-9256), and [CVE-2026-41650](https://nvd.nist.gov/vuln/detail/CVE-2026-41650).
 
 ## [1.1.3] - 2026-05-27


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- Add missing "Security" section header to release notes for v1.1.4.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
