### PR TITLE
fix: prevent job dispatch deadlock when ListTrainingJobs is throttled

### DIFF
--- a/source/apps/infra/lib/constructs/api/__tests__/api.spec.ts
+++ b/source/apps/infra/lib/constructs/api/__tests__/api.spec.ts
@@ -148,7 +148,18 @@ describe('Api', () => {
           FifoQueue: true,
           MessageRetentionPeriod: Duration.days(14).toSeconds(),
           KmsMasterKeyId: 'alias/aws/sqs',
-          VisibilityTimeout: Duration.minutes(1).toSeconds(),
+          VisibilityTimeout: Duration.minutes(12).toSeconds(),
+        }),
+      ).not.toThrow();
+
+      // The workflow job queue must have a dead-letter queue so that a message which
+      // keeps failing cannot block the queue for its entire retention period.
+      expect(() =>
+        template.hasResourceProperties('AWS::SQS::Queue', {
+          FifoQueue: true,
+          RedrivePolicy: {
+            maxReceiveCount: 10,
+          },
         }),
       ).not.toThrow();
 

--- a/source/apps/infra/lib/constructs/api/api.ts
+++ b/source/apps/infra/lib/constructs/api/api.ts
@@ -53,6 +53,8 @@ export interface ApiProps {
 export class Api extends Construct {
   public readonly api: SpecRestApi;
   public readonly workflowJobQueue: Queue;
+
+  public readonly workflowJobDeadLetterQueue: Queue;
   public readonly assetPackagingDLQAlarm: Alarm;
   public readonly importModelJobQueue: Queue;
   public readonly importModelWorkflow: ImportWorkflow;
@@ -64,13 +66,33 @@ export class Api extends Construct {
 
     const { namespace } = props;
 
+    // Dead-letter queue for the workflow job queue. Every message on that queue shares
+    // a single MessageGroupId, so a message at the head that keeps failing blocks the
+    // entire queue (head-of-line blocking). Without a redrive policy such a message is
+    // retried for the whole retention period and the queue never recovers. Capping the
+    // receive count moves the message aside so later jobs can still be dispatched.
+    this.workflowJobDeadLetterQueue = new Queue(this, 'WorkflowJobDeadLetterQueue', {
+      encryption: QueueEncryption.KMS_MANAGED,
+      enforceSSL: true,
+      fifo: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      retentionPeriod: Duration.days(14),
+    });
+
     this.workflowJobQueue = new Queue(this, 'WorkflowJobQueue', {
       encryption: QueueEncryption.KMS_MANAGED,
       enforceSSL: true,
       fifo: true,
       removalPolicy: RemovalPolicy.DESTROY, // TODO: link to config value
       retentionPeriod: Duration.days(14),
-      visibilityTimeout: Duration.minutes(1),
+      // Should be at least six times the consumer Lambda timeout (JobDispatcher is now
+      // 2 minutes); otherwise a message can be delivered again while it is still being
+      // processed, causing the same training job to be dispatched twice.
+      visibilityTimeout: Duration.minutes(12),
+      deadLetterQueue: {
+        queue: this.workflowJobDeadLetterQueue,
+        maxReceiveCount: 10,
+      },
     });
 
     // Entry points for api lambda handlers in the lambda lib

--- a/source/apps/infra/lib/constructs/workflow/workflow.ts
+++ b/source/apps/infra/lib/constructs/workflow/workflow.ts
@@ -357,6 +357,12 @@ export class Workflow extends Construct {
         POWERTOOLS_METRICS_NAMESPACE: 'DeepRacerIndyWorkflow',
       },
       memorySize: 256,
+      // The ListTrainingJobs rate quota is 2 requests/second and is not adjustable, so
+      // the SageMaker client uses adaptive retries with exponential backoff. A single
+      // dispatch can therefore take noticeably longer than before. The 30 second default
+      // is not enough: a Lambda timeout would return the message to the queue and cause
+      // the same training job to be dispatched twice.
+      timeout: Duration.minutes(2),
       role: jobDispatcherRole,
     });
 

--- a/source/libs/lambda/src/utils/clients/sageMakerClient.ts
+++ b/source/libs/lambda/src/utils/clients/sageMakerClient.ts
@@ -6,5 +6,17 @@ import { logger, tracer } from '@deepracer-indy/utils';
 import { getCustomUserAgent } from '@deepracer-indy/utils/src/customUserAgent';
 
 export const sageMakerClient = tracer.captureAWSv3Client(
-  new SageMakerClient({ logger, customUserAgent: getCustomUserAgent() }),
+  new SageMakerClient({
+    logger,
+    customUserAgent: getCustomUserAgent(),
+    // The account-level quota for ListTrainingJobs is 2 requests/second and is not
+    // adjustable. Bursts of calls therefore throttle easily, and the SDK default
+    // (standard mode, 3 attempts) is not enough to absorb them: a ThrottlingException
+    // fails the JobDispatcher invocation, which returns the message to the FIFO queue
+    // and blocks every job behind it.
+    // Adaptive mode adds client-side rate limiting on top of exponential backoff, so
+    // the client slows itself down instead of adding to the congestion.
+    retryMode: 'adaptive',
+    maxAttempts: 10,
+  }),
 );

--- a/source/libs/lambda/src/workflow/utils/SageMakerHelper.ts
+++ b/source/libs/lambda/src/workflow/utils/SageMakerHelper.ts
@@ -24,6 +24,26 @@ import { TrainingInstanceQuotaCode } from '../constants/sageMaker.js';
 import { SimulationLaunchFile } from '../constants/simulation.js';
 import type { SageMakerHyperparameters } from '../types/sageMakerHyperparameters.js';
 
+/**
+ * In-process cache for the training instance quota and current usage.
+ *
+ * Background: JobDispatcher queries the quota and the current usage for every SQS
+ * message it processes. The account-level quota for ListTrainingJobs is 2
+ * requests/second and is not adjustable. Once a burst triggers a
+ * ThrottlingException the dispatcher fails and the message is returned to the FIFO
+ * queue; because every message on that queue shares a single MessageGroupId, a
+ * repeatedly failing message at the head blocks the whole queue (head-of-line
+ * blocking). Caching reduces the call rate enough to avoid that deadlock.
+ *
+ * Lambda execution environments are reused, so module-level state survives across
+ * invocations.
+ */
+const QUOTA_CACHE_TTL_MS = 5 * 60 * 1000; // The quota rarely changes, so it can be cached for longer.
+const USAGE_CACHE_TTL_MS = 10 * 1000; // Usage changes quickly, so cache it only briefly.
+
+let quotaCache: { value: number; expiresAt: number } | undefined;
+let usageCache: { value: number; expiresAt: number } | undefined;
+
 class SageMakerHelper {
   @logMethod
   async createTrainingJob({ jobItem, modelItem }: { jobItem: JobItem; modelItem: ModelItem }) {
@@ -220,6 +240,10 @@ class SageMakerHelper {
   }
 
   async getTrainingInstanceQuota() {
+    if (quotaCache && quotaCache.expiresAt > Date.now()) {
+      return quotaCache.value;
+    }
+
     const instanceQuota = await serviceQuotasHelper.getServiceQuota(
       'sagemaker',
       TrainingInstanceQuotaCode[deepRacerIndyAppConfig.sageMaker.instanceType],
@@ -229,10 +253,17 @@ class SageMakerHelper {
       `SageMaker ${deepRacerIndyAppConfig.sageMaker.instanceType} training instance quota is set to ${instanceQuota.Value}`,
     );
 
-    return instanceQuota.Value as number;
+    const value = instanceQuota.Value as number;
+    quotaCache = { value, expiresAt: Date.now() + QUOTA_CACHE_TTL_MS };
+
+    return value;
   }
 
   async getTrainingInstanceUsage() {
+    if (usageCache && usageCache.expiresAt > Date.now()) {
+      return usageCache.value;
+    }
+
     const TWENTY_FOUR_HOURS_10_MINS_IN_MILLIS = 24 * 60 * 60 * 1000 + 10 * 60 * 1000; // Longest job duration + 10 min buffer
 
     let instanceUsage = 0;
@@ -244,6 +275,9 @@ class SageMakerHelper {
           CreationTimeAfter: new Date(Date.now() - TWENTY_FOUR_HOURS_10_MINS_IN_MILLIS),
           NameContains: 'deepracerindy',
           StatusEquals: TrainingJobStatus.IN_PROGRESS,
+          // Request the maximum page size (the default is only 10) to reduce the number
+          // of paginated requests and stay within the rate limit.
+          MaxResults: 100,
         },
       )) {
         instanceUsage += result.TrainingJobSummaries?.length ?? 0;
@@ -254,10 +288,13 @@ class SageMakerHelper {
           CreationTimeAfter: new Date(Date.now() - TWENTY_FOUR_HOURS_10_MINS_IN_MILLIS),
           NameContains: 'deepracerindy',
           StatusEquals: TrainingJobStatus.STOPPING,
+          MaxResults: 100,
         },
       )) {
         instanceUsage += result.TrainingJobSummaries?.length ?? 0;
       }
+
+      usageCache = { value: instanceUsage, expiresAt: Date.now() + USAGE_CACHE_TTL_MS };
 
       return instanceUsage;
     } catch (error) {
@@ -276,10 +313,21 @@ class SageMakerHelper {
 
     if (isCapacityAvailable) {
       logger.info(`Active SageMaker training instances [${instanceUsage}] is less than quota [${instanceQuota}]`);
+      // Capacity is available, so the caller is about to dispatch a job. Increment the
+      // cached usage optimistically so that consecutive dispatches within the cache TTL
+      // do not all read the same stale value and exceed the quota.
+      // If the dispatch ultimately fails, this only errs on the conservative side
+      // (dispatching fewer jobs) and can never exceed the quota.
+      if (usageCache) {
+        usageCache.value += 1;
+      }
     } else {
       logger.warn(
         `Active SageMaker training instances [${instanceUsage}] is equal to or greater than quota [${instanceQuota}]`,
       );
+      // No capacity left: clear the cache so the next check reads the real usage and the
+      // dispatcher does not stay stuck believing it is at capacity.
+      usageCache = undefined;
     }
 
     return isCapacityAvailable;

--- a/source/libs/lambda/src/workflow/utils/__tests__/SageMakerHelper.spec.ts
+++ b/source/libs/lambda/src/workflow/utils/__tests__/SageMakerHelper.spec.ts
@@ -4,6 +4,7 @@
 import {
   CreateTrainingJobCommand,
   DescribeTrainingJobCommandOutput,
+  ListTrainingJobsCommand,
   SageMakerClient,
   StopTrainingJobCommand,
   TrainingJobStatus,
@@ -175,6 +176,123 @@ describe('SageMakerHelper', () => {
       );
 
       expect(mockSageMakerClient.commandCalls(StopTrainingJobCommand)).toHaveLength(0);
+    });
+  });
+  describe('isTrainingInstanceCapacityAvailable()', () => {
+    const QUOTA = 4;
+
+    /**
+     * The quota and usage caches are module-level state, so each test imports a fresh
+     * copy of the module to start from an empty cache.
+     */
+    const importFreshHelper = async () => {
+      vi.resetModules();
+      const module = await import('../SageMakerHelper.js');
+      return module.sageMakerHelper;
+    };
+
+    const mockQuota = async (value = QUOTA) => {
+      const { serviceQuotasHelper } = await import('../ServiceQuotasHelper.js');
+      return vi.spyOn(serviceQuotasHelper, 'getServiceQuota').mockResolvedValue({ Value: value });
+    };
+
+    /** Mocks ListTrainingJobs so that it reports `count` in-progress jobs on a single page. */
+    const mockInProgressJobs = (count: number) => {
+      mockSageMakerClient.on(ListTrainingJobsCommand).resolves({
+        TrainingJobSummaries: Array.from({ length: count }, (_, index) => ({
+          TrainingJobName: `deepracerindy-job-${index}`,
+        })),
+        NextToken: undefined,
+      });
+    };
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      mockSageMakerClient.reset();
+    });
+
+    it('should request the maximum page size to limit the number of ListTrainingJobs calls', async () => {
+      const helper = await importFreshHelper();
+      await mockQuota();
+      mockInProgressJobs(1);
+
+      await helper.isTrainingInstanceCapacityAvailable();
+
+      const calls = mockSageMakerClient.commandCalls(ListTrainingJobsCommand);
+      expect(calls.length).toBeGreaterThan(0);
+      calls.forEach((call) => {
+        expect(call.args[0].input.MaxResults).toBe(100);
+      });
+    });
+
+    it('should return true when usage is below the quota', async () => {
+      const helper = await importFreshHelper();
+      await mockQuota();
+      mockInProgressJobs(1);
+
+      await expect(helper.isTrainingInstanceCapacityAvailable()).resolves.toBe(true);
+    });
+
+    it('should return false when usage has reached the quota', async () => {
+      const helper = await importFreshHelper();
+      await mockQuota(2);
+      // Both the IN_PROGRESS and the STOPPING query resolve to one job each.
+      mockInProgressJobs(1);
+
+      await expect(helper.isTrainingInstanceCapacityAvailable()).resolves.toBe(false);
+    });
+
+    it('should cache the quota lookup between consecutive checks', async () => {
+      const helper = await importFreshHelper();
+      const getServiceQuota = await mockQuota();
+      mockInProgressJobs(1);
+
+      await helper.isTrainingInstanceCapacityAvailable();
+      await helper.isTrainingInstanceCapacityAvailable();
+
+      expect(getServiceQuota).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cache the usage lookup so a second check issues no further ListTrainingJobs calls', async () => {
+      const helper = await importFreshHelper();
+      await mockQuota(10);
+      mockInProgressJobs(1);
+
+      await helper.isTrainingInstanceCapacityAvailable();
+      const callsAfterFirstCheck = mockSageMakerClient.commandCalls(ListTrainingJobsCommand).length;
+
+      await helper.isTrainingInstanceCapacityAvailable();
+
+      expect(mockSageMakerClient.commandCalls(ListTrainingJobsCommand)).toHaveLength(callsAfterFirstCheck);
+    });
+
+    it('should optimistically increment cached usage so consecutive dispatches cannot exceed the quota', async () => {
+      const helper = await importFreshHelper();
+      // Quota of 3 with two jobs already running (one IN_PROGRESS, one STOPPING).
+      await mockQuota(3);
+      mockInProgressJobs(1);
+
+      // First check sees usage 2 < 3 and increments the cached usage to 3.
+      await expect(helper.isTrainingInstanceCapacityAvailable()).resolves.toBe(true);
+      // Second check must observe the incremented value instead of the stale usage.
+      await expect(helper.isTrainingInstanceCapacityAvailable()).resolves.toBe(false);
+    });
+
+    it('should clear the usage cache when no capacity is available', async () => {
+      const helper = await importFreshHelper();
+      await mockQuota(2);
+      mockInProgressJobs(1);
+
+      await expect(helper.isTrainingInstanceCapacityAvailable()).resolves.toBe(false);
+      const callsAfterFirstCheck = mockSageMakerClient.commandCalls(ListTrainingJobsCommand).length;
+
+      // The cache was cleared, so the next check must query the real usage again rather
+      // than staying stuck believing the account is at capacity.
+      await helper.isTrainingInstanceCapacityAvailable();
+
+      expect(mockSageMakerClient.commandCalls(ListTrainingJobsCommand).length).toBeGreaterThan(
+        callsAfterFirstCheck,
+      );
     });
   });
 });


### PR DESCRIPTION
_Issue #, if available:_ #87

_Description of changes:_

Training job dispatch can stop completely and never recover, while the SageMaker training instance quota sits almost entirely unused. Three defects combine to cause this.

**1. Throttling is not absorbed.** `getTrainingInstanceUsage()` calls `ListTrainingJobs`, whose account-level quota is 2 requests/second and is **not adjustable**. The call paginates with the default page size of 10, so one capacity check issues several requests back to back — with ~38 running jobs that is about 5 requests within milliseconds, which alone exceeds the quota. The SDK default retry configuration (`standard`, 3 attempts) exhausts itself inside one second, entirely within the saturation window it just created, and the invocation fails.

Note that this scales with load: with only a few running jobs a capacity check fits in a single page and the problem does not appear, which is why it surfaces once concurrency rises.

**2. Head-of-line blocking.** Every message on the workflow job queue shares a single `MessageGroupId`, so a failing message at the head blocks every job behind it.

**3. No redrive policy.** With `RedrivePolicy: None` and 14 day retention the message is retried indefinitely, and each retry issues more `ListTrainingJobs` calls, which sustains the throttling. The queue never self-heals.

**Changes**

- `sageMakerClient`: `retryMode: 'adaptive'` with `maxAttempts: 10`, so the client rate-limits itself rather than adding to the congestion.
- `SageMakerHelper`: cache the quota (5 minutes) and usage (10 seconds) lookups and request `MaxResults: 100`. When capacity is available the cached usage is incremented optimistically so consecutive dispatches cannot exceed the quota; when capacity is exhausted the cache is cleared so the dispatcher does not stay stuck. The bias is always conservative — it can under-dispatch, never over-dispatch.
- `workflow`: JobDispatcher timeout 30 s to 2 minutes, to allow for backoff.
- `api`: queue visibility timeout 1 minute to 12 minutes (keeping the recommended ratio of at least six times the consumer timeout), plus a FIFO dead-letter queue with `maxReceiveCount: 10`.

**Verification**

Deployed to a live deployment in `ap-northeast-1` serving roughly 19 concurrent users:

| | Before | After |
|---|---|---|
| Queue backlog | 34, draining 0/min | **0** |
| Dead-letter queue | n/a | **0** (no messages lost) |
| Running training jobs | 29 | 38 |
| JobDispatcher error rate | 100% | 0% |

That the dead-letter queue stayed empty is worth noting: every backlogged message eventually succeeded, which confirms no message was itself malformed — the dispatcher was failing regardless of message content.

Tests: added coverage for the caching behaviour, the optimistic increment, cache invalidation when capacity is exhausted, and the requested page size. Updated the existing `Api` construct test for the new visibility timeout and added an assertion for the dead-letter queue. Full suite: **2812 passed, 0 failed**.

This pull request deliberately excludes a separate WAF change we run locally (reported as #89), since that one involves a security trade-off better decided by the maintainers.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
